### PR TITLE
fix scm urls, repo is dependencies, not gridsuite-dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/gridsuite/gridsuite-dependencies.git</connection>
-        <developerConnection>scm:git:https://github.com/gridsuite/gridsuite-dependencies.git</developerConnection>
-        <url>https://github.com/gridsuite/gridsuite-dependencies/tree/main/</url>
+        <connection>scm:git:https://github.com/gridsuite/dependencies.git</connection>
+        <developerConnection>scm:git:https://github.com/gridsuite/dependencies.git</developerConnection>
+        <url>https://github.com/gridsuite/dependencies/tree/main/</url>
     </scm>
 
     <properties>


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>